### PR TITLE
Handle non-ObjectID ids

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -1,0 +1,7 @@
+var ObjectID = require('mongodb').ObjectID;
+
+module.exports.idForRequestId = function (request_id) {
+  return (request_id.length == 12 || request_id.match(/^[0-9a-f]{24}$/)) ?
+                                        ObjectID(request_id) : request_id;
+
+};

--- a/routes/docChange.js
+++ b/routes/docChange.js
@@ -7,6 +7,7 @@ var config = require('../lib/config')
   , db = require('../lib/db')
   , ObjectID = require('mongodb').ObjectID
   , serialization = require('../lib/serialization')
+  , helpers = require('../lib/helpers')
   ;
 
 module.exports = function (req, res, next) {
@@ -28,11 +29,9 @@ module.exports = function (req, res, next) {
 
   delete newDoc._id;   // Mongo won't be able to update the doc if it thinks we want to change it's _id
 
-  docId = (req.params.id.length == 12 || req.params.id.match(/^[0-9a-f]{24}$/)) ?
-                                               ObjectID(req.params.id) : req.params.id;
-
   collection = db.collection(req.params.collection);
-  collection.update({ _id: docId }, newDoc, { safe: true }, function (err) {
+  collection.update({ _id: helpers.idForRequestId(req.params.id) },
+                              newDoc, { safe: true }, function (err) {
     if (err) {
       return res.json(403, err);
     }

--- a/routes/docChange.js
+++ b/routes/docChange.js
@@ -28,8 +28,11 @@ module.exports = function (req, res, next) {
 
   delete newDoc._id;   // Mongo won't be able to update the doc if it thinks we want to change it's _id
 
+  docId = (req.params.id.length == 12 || req.params.id.match(/^[0-9a-f]{24}$/)) ?
+                                               ObjectID(req.params.id) : req.params.id;
+
   collection = db.collection(req.params.collection);
-  collection.update({ _id: new ObjectID(req.params.id) }, newDoc, { safe: true }, function (err) {
+  collection.update({ _id: docId }, newDoc, { safe: true }, function (err) {
     if (err) {
       return res.json(403, err);
     }

--- a/routes/docDelete.js
+++ b/routes/docDelete.js
@@ -7,6 +7,7 @@ var config = require('../lib/config')
   , db = require('../lib/db')
   , ObjectID = require('mongodb').ObjectID
   , serialization = require('../lib/serialization')
+  , helpers = require('../lib/helpers')
   ;
 
 module.exports = function (req, res, next) {
@@ -17,7 +18,8 @@ module.exports = function (req, res, next) {
   }
 
   collection = db.collection(req.params.collection);
-  collection.remove({ _id: new ObjectID(req.params.id) }, { single: true, w:1 }, function (err) {
+  collection.remove({ _id: helpers.idForRequestId(req.params.id) },
+                    { single: true, w:1 }, function (err) {
     if (err) { return res.json(403, err); }
 
     return res.redirect(config.baseUrl + '/' + req.params.collection + '?type=alert-success&message=The document was deleted, no turning back now!');

--- a/routes/docEdit.js
+++ b/routes/docEdit.js
@@ -7,6 +7,7 @@ var config = require('../lib/config')
   , db = require('../lib/db')
   , ObjectID = require('mongodb').ObjectID
   , serialization = require('../lib/serialization')
+  , helpers = require('../lib/helpers')
   ;
 
 module.exports = function (req, res, next) {
@@ -21,8 +22,7 @@ module.exports = function (req, res, next) {
   }
 
   try {
-    docId = (req.params.id.length == 12 || req.params.id.match(/^[0-9a-f]{24}$/)) ? 
-                                             ObjectID(req.params.id) : req.params.id;
+    docId = helpers.idForRequestId(req.params.id);
   } catch (e) {
     return res.send(400, e.toString());
   }

--- a/routes/docEdit.js
+++ b/routes/docEdit.js
@@ -21,7 +21,8 @@ module.exports = function (req, res, next) {
   }
 
   try {
-    docId = new ObjectID(req.params.id);
+    docId = (req.params.id.length == 12 || req.params.id.match(/^[0-9a-f]{24}$/)) ? 
+                                             ObjectID(req.params.id) : req.params.id;
   } catch (e) {
     return res.send(400, e.toString());
   }


### PR DESCRIPTION
Apologies for not creating a separate branch. ObjectIDs are always either 12 bytes or 24 hex characters; anything else is a custom ID and should be handled as such.
